### PR TITLE
Add support for configuring the integration's offsets

### DIFF
--- a/custom_components/purpleair/PurpleAirApi.py
+++ b/custom_components/purpleair/PurpleAirApi.py
@@ -4,29 +4,42 @@ import logging
 import math
 
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers.event import async_track_time_interval, async_track_point_in_utc_time
+from homeassistant.helpers.event import (
+    async_track_time_interval,
+    async_track_point_in_utc_time,
+)
 from homeassistant.util import dt
 
-from .const import AQI_BREAKPOINTS, DISPATCHER_PURPLE_AIR, PARTICLE_PROPS, LOCAL_SCAN_INTERVAL, LOCAL_URL_FORMAT, \
-    TEMP_ADJUSTMENT, HUMIDITY_ADJUSTMENT
+from .const import (
+    AQI_BREAKPOINTS,
+    DISPATCHER_PURPLE_AIR,
+    PARTICLE_PROPS,
+    LOCAL_SCAN_INTERVAL,
+    LOCAL_URL_FORMAT,
+    TEMP_ADJUSTMENT,
+    HUMIDITY_ADJUSTMENT,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 
 def calc_aqi(value, index):
     if index not in AQI_BREAKPOINTS:
-        _LOGGER.debug('calc_aqi requested for unknown type: %s', index)
+        _LOGGER.debug("calc_aqi requested for unknown type: %s", index)
         return None
 
-    bp = next((bp for bp in AQI_BREAKPOINTS[index] if bp['pm_low'] <= value <= bp['pm_high']), None)
+    bp = next(
+        (bp for bp in AQI_BREAKPOINTS[index] if bp["pm_low"] <= value <= bp["pm_high"]),
+        None,
+    )
     if not bp:
-        _LOGGER.debug('value %s did not fall in valid range for type %s', value, index)
+        _LOGGER.debug("value %s did not fall in valid range for type %s", value, index)
         return None
 
-    aqi_range = bp['aqi_high'] - bp['aqi_low']
-    pm_range = bp['pm_high'] - bp['pm_low']
-    c = value - bp['pm_low']
-    return round((aqi_range/pm_range) * c + bp['aqi_low'])
+    aqi_range = bp["aqi_high"] - bp["aqi_low"]
+    pm_range = bp["pm_high"] - bp["pm_low"]
+    c = value - bp["pm_low"]
+    return round((aqi_range / pm_range) * c + bp["aqi_low"])
 
 
 # LRAPA conversion using the same formula as used by PurpleAir's map as of 2020-09-06
@@ -40,33 +53,43 @@ def calc_dewpoint(temp_f, humidity):
     Note: Rounding twice for both F>C and C>F conversions simply because the purpleair website does this (so I
     do this too, to match the purpleair website).
     """
-    temp_c = round((temp_f - 32) * 5.0/9.0)
+    temp_c = round((temp_f - 32) * 5.0 / 9.0)
 
-    numerator = 243.04 * (math.log(humidity / 100) + ((17.625 * temp_c) / (243.04 + temp_c)))
-    denominator = 17.625 - math.log(humidity / 100) - ((17.625 * temp_c) / (243.04 + temp_c))
+    numerator = 243.04 * (
+        math.log(humidity / 100) + ((17.625 * temp_c) / (243.04 + temp_c))
+    )
+    denominator = (
+        17.625 - math.log(humidity / 100) - ((17.625 * temp_c) / (243.04 + temp_c))
+    )
     dew_point_c = numerator / denominator
 
-    dew_point_f = round((dew_point_c * 9/5) + 32)
+    dew_point_f = round((dew_point_c * 9 / 5) + 32)
     return dew_point_f
 
 
-def process_heat_adjustments(json_result):
+def process_heat_adjustments(json_result, temp_offset=None, humidity_offset=None):
     """Since the purple air devices are affected by heat from itself, modify readings to account for difference"""
-    new_temp = json_result['current_temp_f'] + TEMP_ADJUSTMENT
-    new_humid = min(100, json_result['current_humidity'] + HUMIDITY_ADJUSTMENT)
+    # Use provided offsets or fall back to defaults
+    if temp_offset is None:
+        temp_offset = TEMP_ADJUSTMENT
+    if humidity_offset is None:
+        humidity_offset = HUMIDITY_ADJUSTMENT
+
+    new_temp = json_result["current_temp_f"] + temp_offset
+    new_humid = min(100, json_result["current_humidity"] + humidity_offset)
 
     return {
-        'current_temp': new_temp,
-        'current_humidity': new_humid,
-        'current_dewpoint': calc_dewpoint(new_temp, new_humid)
+        "current_temp": new_temp,
+        "current_humidity": new_humid,
+        "current_dewpoint": calc_dewpoint(new_temp, new_humid),
     }
 
 
-def process_pm_readings(json_result, is_dual = False):
+def process_pm_readings(json_result, is_dual=False):
     """Processes Particle mass readings and confidence of said readings"""
-    readings = {'pm2_5_aqi_raw': json_result['pm2.5_aqi']}
+    readings = {"pm2_5_aqi_raw": json_result["pm2.5_aqi"]}
     if is_dual:
-        readings['pm2_5_aqi_b_raw'] = json_result['pm2.5_aqi_b']
+        readings["pm2_5_aqi_b_raw"] = json_result["pm2.5_aqi_b"]
 
     for prop in PARTICLE_PROPS:
         if prop not in json_result:
@@ -74,32 +97,35 @@ def process_pm_readings(json_result, is_dual = False):
             continue
 
         a = float(json_result[prop])
-        prop_b = prop + '_b'  # Property name for sensor B
+        prop_b = prop + "_b"  # Property name for sensor B
         if is_dual and prop_b in json_result:
-            (value, confidence) = process_dual_sensor_readings(a, float(json_result[prop_b]))
+            (value, confidence) = process_dual_sensor_readings(
+                a, float(json_result[prop_b])
+            )
         else:
             value = a
-            confidence = 'Good'
+            confidence = "Good"
 
         readings[prop] = value
-        readings[f'{prop}_conf'] = confidence
+        readings[f"{prop}_conf"] = confidence
 
-    readings['aqi_epa'] = calc_aqi(readings['pm2_5_atm'], 'pm2_5')
-    readings['aqi_lrapa'] = calc_aqi(lrapa(readings['pm2_5_atm']), 'pm2_5')
+    readings["aqi_epa"] = calc_aqi(readings["pm2_5_atm"], "pm2_5")
+    readings["aqi_lrapa"] = calc_aqi(lrapa(readings["pm2_5_atm"]), "pm2_5")
     return readings
+
 
 def process_dual_sensor_readings(a, b):
     value = round((a + b) / 2, 1)
 
     if abs(a - b) < 45:
-        confidence = 'Good'
+        confidence = "Good"
     elif abs(a - b) > 300:
         # If the readings are so severly different, one is probably affected by a
         # physical obstuction (spider?), so just throw it away and use the smaller value.
-        confidence = 'Severe'
+        confidence = "Severe"
         value = min(a, b)
     else:
-        confidence = 'Questionable'
+        confidence = "Questionable"
 
     return (value, confidence)
 
@@ -112,6 +138,7 @@ class PurpleAirApi:
         self._data = {}
         self._scan_interval = timedelta(seconds=LOCAL_SCAN_INTERVAL)
         self._shutdown_interval = None
+        self._node_configs = {}  # Store per-node configuration
 
     def is_node_registered(self, pa_sensor_id):
         return pa_sensor_id in self._data
@@ -123,89 +150,102 @@ class PurpleAirApi:
         node = self._data[pa_sensor_id]
         return node[prop] if prop in node else None
 
-    def register_node(self, pa_sensor_id, ip_address):
+    def register_node(
+        self, pa_sensor_id, ip_address, temp_offset=None, humidity_offset=None
+    ):
         if pa_sensor_id in self._nodes:
-            _LOGGER.debug('detected duplicate registration: %s', pa_sensor_id)
+            _LOGGER.debug("detected duplicate registration: %s", pa_sensor_id)
             return
 
-        self._nodes[pa_sensor_id] = { 'ip_address': ip_address }
-        _LOGGER.debug('registered new node: %s', pa_sensor_id)
+        self._nodes[pa_sensor_id] = {"ip_address": ip_address}
+        self._node_configs[pa_sensor_id] = {
+            "temp_offset": temp_offset if temp_offset is not None else TEMP_ADJUSTMENT,
+            "humidity_offset": humidity_offset
+            if humidity_offset is not None
+            else HUMIDITY_ADJUSTMENT,
+        }
+        _LOGGER.debug("registered new node: %s", pa_sensor_id)
 
         if not self._shutdown_interval:
-            _LOGGER.debug('starting background poll: %s', self._scan_interval)
+            _LOGGER.debug("starting background poll: %s", self._scan_interval)
             self._shutdown_interval = async_track_time_interval(
-                self._hass,
-                self._update,
-                self._scan_interval
+                self._hass, self._update, self._scan_interval
             )
 
             async_track_point_in_utc_time(
-                self._hass,
-                self._update,
-                dt.utcnow() + timedelta(seconds=5)
+                self._hass, self._update, dt.utcnow() + timedelta(seconds=5)
             )
 
     def unregister_node(self, pa_sensor_id):
         if pa_sensor_id not in self._nodes:
-            _LOGGER.debug('detected non-existent unregistration: %s', pa_sensor_id)
+            _LOGGER.debug("detected non-existent unregistration: %s", pa_sensor_id)
             return
 
         del self._nodes[pa_sensor_id]
-        _LOGGER.debug('unregistered node: %s', pa_sensor_id)
+        _LOGGER.debug("unregistered node: %s", pa_sensor_id)
 
         if not self._nodes and self._shutdown_interval:
-            _LOGGER.debug('no more nodes, shutting down interval')
+            _LOGGER.debug("no more nodes, shutting down interval")
             self._shutdown_interval()
             self._shutdown_interval = None
 
-
     async def _fetch_data(self, local_node_ips):
         if not local_node_ips:
-            _LOGGER.debug('no nodes provided')
+            _LOGGER.debug("no nodes provided")
             return []
 
         urls = list(map(LOCAL_URL_FORMAT.format, local_node_ips))
-        _LOGGER.debug('fetch url list: %s', urls)
+        _LOGGER.debug("fetch url list: %s", urls)
 
         results = []
         for url in urls:
-            _LOGGER.debug('fetching url: %s', url)
+            _LOGGER.debug("fetching url: %s", url)
 
             try:
                 async with self._session.get(url) as response:
                     if response.status != 200:
-                        _LOGGER.error('bad API response for %s: %s', url, response.status)
+                        _LOGGER.error(
+                            "bad API response for %s: %s", url, response.status
+                        )
 
                     json = await response.json()
                     results.append(json)
             except Exception:
-                _LOGGER.error('Unable to connect to purple air device: ' + url)
+                _LOGGER.error("Unable to connect to purple air device: " + url)
 
         return results
 
     async def _update(self, now=None):
-        local_node_ips = [n['ip_address'] for n in self._nodes.values()]
-        _LOGGER.debug('Purple Air nodes: %s', local_node_ips)
+        local_node_ips = [n["ip_address"] for n in self._nodes.values()]
+        _LOGGER.debug("Purple Air nodes: %s", local_node_ips)
 
         results = await self._fetch_data(local_node_ips)
 
         nodes = {}
         for result in results:
-            pa_sensor_id = result['SensorId']
-            is_dual = 'pm2.5_aqi_b' in result
+            pa_sensor_id = result["SensorId"]
+            is_dual = "pm2.5_aqi_b" in result
+
+            # Get node-specific configuration
+            node_config = self._node_configs.get(pa_sensor_id, {})
+            temp_offset = node_config.get("temp_offset", TEMP_ADJUSTMENT)
+            humidity_offset = node_config.get("humidity_offset", HUMIDITY_ADJUSTMENT)
+
             nodes[pa_sensor_id] = {
-                'device_location': result['place'],
-                'rssi': result['rssi'],
-                'current_temp_raw': result['current_temp_f'],
-                'current_humidity_raw': result['current_humidity'],
-                'current_dewpoint_raw': result['current_dewpoint_f'],
-                'pressure': result['pressure'],
-                'is_dual': is_dual
+                "device_location": result["place"],
+                "rssi": result["rssi"],
+                "current_temp_raw": result["current_temp_f"],
+                "current_humidity_raw": result["current_humidity"],
+                "current_dewpoint_raw": result["current_dewpoint_f"],
+                "pressure": result["pressure"],
+                "is_dual": is_dual,
             }
             nodes[pa_sensor_id].update(process_pm_readings(result, is_dual))
-            nodes[pa_sensor_id].update(process_heat_adjustments(result))
-            _LOGGER.debug('Json results for %s: %s', pa_sensor_id, result)
-            _LOGGER.debug('Readings for %s: %s', pa_sensor_id, nodes[pa_sensor_id])
+            nodes[pa_sensor_id].update(
+                process_heat_adjustments(result, temp_offset, humidity_offset)
+            )
+            _LOGGER.debug("Json results for %s: %s", pa_sensor_id, result)
+            _LOGGER.debug("Readings for %s: %s", pa_sensor_id, nodes[pa_sensor_id])
 
         self._data = nodes
         async_dispatcher_send(self._hass, DISPATCHER_PURPLE_AIR)

--- a/custom_components/purpleair/config_flow.py
+++ b/custom_components/purpleair/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for Purple Air integration."""
+
 import logging
 import voluptuous as vol
 import socket  # Used to validate IP address
@@ -7,7 +8,19 @@ from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_IP_ADDRESS, CONF_NAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN, LOCAL_URL_FORMAT, PMS_SENSOR, BME_SENSOR, MODEL_PA_1, MODEL_PA_2, MODEL_PA_FLEX
+from .const import (
+    DOMAIN,
+    LOCAL_URL_FORMAT,
+    PMS_SENSOR,
+    BME_SENSOR,
+    MODEL_PA_1,
+    MODEL_PA_2,
+    MODEL_PA_FLEX,
+    TEMP_ADJUSTMENT,
+    HUMIDITY_ADJUSTMENT,
+    CONF_TEMP_OFFSET,
+    CONF_HUMIDITY_OFFSET,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -20,10 +33,10 @@ async def validate_input(hass: core.HomeAssistant, data):
 
     json = {}
     client = async_get_clientsession(hass)
-    name = data['name']
-    ip_address = data['ip_address']
+    name = data["name"]
+    ip_address = data["ip_address"]
     url = LOCAL_URL_FORMAT.format(ip_address)
-    _LOGGER.debug('Using ip_address: %s. URL: %s', (ip_address, url))
+    _LOGGER.debug("Using ip_address: %s. URL: %s", ip_address, url)
 
     try:
         socket.inet_aton(ip_address)
@@ -37,17 +50,19 @@ async def validate_input(hass: core.HomeAssistant, data):
         json = await resp.json()
 
     config = {
-        'title': name,
-        'place': json['place'],
-        'id': str(json['SensorId']),
-        'ip_address': ip_address,
-        'sw_version': json['version'],
-        'hw_version': json['hardwareversion'],
-        'model': get_model_name(json['hardwarediscovered']),
-        'is_dual': ('pm2.5_aqi_b' in json)
+        "title": name,
+        "place": json["place"],
+        "id": str(json["SensorId"]),
+        "ip_address": ip_address,
+        "sw_version": json["version"],
+        "hw_version": json["hardwareversion"],
+        "model": get_model_name(json["hardwarediscovered"]),
+        "is_dual": ("pm2.5_aqi_b" in json),
+        CONF_TEMP_OFFSET: data.get(CONF_TEMP_OFFSET, TEMP_ADJUSTMENT),
+        CONF_HUMIDITY_OFFSET: data.get(CONF_HUMIDITY_OFFSET, HUMIDITY_ADJUSTMENT),
     }
 
-    _LOGGER.debug('generated config data: %s', config)
+    _LOGGER.debug("generated config data: %s", config)
     return config
 
 
@@ -67,13 +82,18 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
+    @staticmethod
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return OptionsFlowHandler()
+
     async def async_step_user(self, user_input=None):
         errors = {}
         if user_input is not None:
             try:
                 info = await validate_input(self.hass, user_input)
 
-                await self.async_set_unique_id(info['id'])
+                await self.async_set_unique_id(info["id"])
                 self._abort_if_unique_id_configured()
 
                 return self.async_create_entry(title=info["title"], data=info)
@@ -91,6 +111,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             {
                 vol.Required(CONF_IP_ADDRESS): str,
                 vol.Required(CONF_NAME): str,
+                vol.Optional(CONF_TEMP_OFFSET, default=TEMP_ADJUSTMENT): vol.Coerce(
+                    int
+                ),
+                vol.Optional(
+                    CONF_HUMIDITY_OFFSET, default=HUMIDITY_ADJUSTMENT
+                ): vol.Coerce(int),
             }
         )
 
@@ -106,14 +132,51 @@ class CannotConnect(exceptions.HomeAssistantError):
 class InvalidAuth(exceptions.HomeAssistantError):
     """Error to indicate there is invalid auth."""
 
+
 class InvalidIp(exceptions.HomeAssistantError):
     """Error to indicate there is invalid config IP Address."""
 
     def __init__(self, response):
         self.response = response
 
+
 class InvalidResponse(exceptions.HomeAssistantError):
     """Error to indicate a bad HTTP response."""
 
     def __init__(self, response):
         self.response = response
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle options flow for PurpleAir."""
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_TEMP_OFFSET,
+                        default=self.config_entry.options.get(
+                            CONF_TEMP_OFFSET,
+                            self.config_entry.data.get(
+                                CONF_TEMP_OFFSET, TEMP_ADJUSTMENT
+                            ),
+                        ),
+                    ): vol.Coerce(int),
+                    vol.Optional(
+                        CONF_HUMIDITY_OFFSET,
+                        default=self.config_entry.options.get(
+                            CONF_HUMIDITY_OFFSET,
+                            self.config_entry.data.get(
+                                CONF_HUMIDITY_OFFSET, HUMIDITY_ADJUSTMENT
+                            ),
+                        ),
+                    ): vol.Coerce(int),
+                }
+            ),
+        )

--- a/custom_components/purpleair/const.py
+++ b/custom_components/purpleair/const.py
@@ -52,6 +52,10 @@ HUMIDITY_ADJUSTMENT = (
     +4
 )  # From PurpleAir javascript: `(hum = parseInt(hum) + 4) > 100 && (hum = 100)`
 
+# Configuration keys
+CONF_TEMP_OFFSET = "temp_offset"
+CONF_HUMIDITY_OFFSET = "humidity_offset"
+
 LOCAL_SCAN_INTERVAL = 30
 LOCAL_URL_FORMAT = "http://{0}/json?live=false"
 

--- a/custom_components/purpleair/manifest.json
+++ b/custom_components/purpleair/manifest.json
@@ -1,15 +1,15 @@
 {
   "domain": "purpleair",
   "name": "PurpleAir (Local)",
-  "version": "2.1.0",
-  "iot_class": "local_polling",
+  "codeowners": ["@gibwar", "@catchdave", "@offbyone"],
   "config_flow": true,
+  "dependencies": [],
   "documentation": "https://github.com/offbyone/home-assistant-purpleair",
+  "homekit": {},
+  "iot_class": "local_polling",
+  "issue_tracker": "https://github.com/offbyone/home-assistant-purpleair/issues",
   "requirements": [],
   "ssdp": [],
-  "zeroconf": [],
-  "homekit": {},
-  "dependencies": [],
-  "codeowners": ["@gibwar", "@catchdave", "@offbyone"],
-  "issue_tracker": "https://github.com/offbyone/home-assistant-purpleair/issues"
+  "version": "2.1.0",
+  "zeroconf": []
 }

--- a/custom_components/purpleair/sensor.py
+++ b/custom_components/purpleair/sensor.py
@@ -1,61 +1,95 @@
-""" The Purple Air air_quality platform. """
+"""The Purple Air air_quality platform."""
+
 import logging
 
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.components.sensor import SensorEntity
 
-from .const import DISPATCHER_PURPLE_AIR, DOMAIN, MANUFACTURER, SENSORS_MAP, SENSORS_DUAL_ONLY, MODEL_PA_FLEX, MODEL_PA_2
+from .const import (
+    DISPATCHER_PURPLE_AIR,
+    DOMAIN,
+    MANUFACTURER,
+    SENSORS_MAP,
+    SENSORS_DUAL_ONLY,
+    MODEL_PA_FLEX,
+    MODEL_PA_2,
+    CONF_TEMP_OFFSET,
+    CONF_HUMIDITY_OFFSET,
+    TEMP_ADJUSTMENT,
+    HUMIDITY_ADJUSTMENT,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, config_entry, async_schedule_add_entities):
-    _LOGGER.debug('Registering aqi sensor with data: %s', config_entry.data)
+    _LOGGER.debug("Registering aqi sensor with data: %s", config_entry.data)
 
     # Backwards compat for sensors added before 'is_dual' key created in config_flow
-    if 'is_dual' in config_entry.data:
-        is_dual = config_entry.data['is_dual']
+    if "is_dual" in config_entry.data:
+        is_dual = config_entry.data["is_dual"]
     else:
-        is_dual = config_entry.data['model'] in [MODEL_PA_FLEX, MODEL_PA_2]  # Backup to test for dual sensors
+        is_dual = config_entry.data["model"] in [
+            MODEL_PA_FLEX,
+            MODEL_PA_2,
+        ]  # Backup to test for dual sensors
+
+    # Get offset values from options first, then data, then defaults
+    temp_offset = config_entry.options.get(
+        CONF_TEMP_OFFSET, config_entry.data.get(CONF_TEMP_OFFSET, TEMP_ADJUSTMENT)
+    )
+    humidity_offset = config_entry.options.get(
+        CONF_HUMIDITY_OFFSET,
+        config_entry.data.get(CONF_HUMIDITY_OFFSET, HUMIDITY_ADJUSTMENT),
+    )
 
     entities = []
     for index, entity_desc in SENSORS_MAP.items():
-        if is_dual or entity_desc['key'] not in SENSORS_DUAL_ONLY:
-            entities.append(PurpleAirQualitySensor(hass, index, config_entry, entity_desc))
+        if is_dual or entity_desc["key"] not in SENSORS_DUAL_ONLY:
+            entities.append(
+                PurpleAirQualitySensor(
+                    hass, index, config_entry, entity_desc, temp_offset, humidity_offset
+                )
+            )
 
     async_schedule_add_entities(entities)
 
 
 class PurpleAirQualitySensor(SensorEntity):
     """Sensor data reading from purple air device"""
-    def __init__(self, hass, index, config_entry, entity_desc):
+
+    def __init__(
+        self, hass, index, config_entry, entity_desc, temp_offset, humidity_offset
+    ):
         self._data = config_entry.data
         self._hass = hass
         self._api = hass.data[DOMAIN]
         self._stop_listening = None
+        self._temp_offset = temp_offset
+        self._humidity_offset = humidity_offset
 
-        self._uom = entity_desc['uom']
-        self._icon = entity_desc['icon']
-        self._src_key = entity_desc['key']
+        self._uom = entity_desc["uom"]
+        self._icon = entity_desc["icon"]
+        self._src_key = entity_desc["key"]
 
         self.idx = index
-        self.pa_sensor_id = self._data['id']
-        self.pa_sensor_name = self._data['title']
-        self.pa_ip_address = self._data['ip_address']
+        self.pa_sensor_id = self._data["id"]
+        self.pa_sensor_name = self._data["title"]
+        self.pa_ip_address = self._data["ip_address"]
 
     @property
     def device_info(self):
         return {
-           "identifiers": {
-               # Serial numbers are unique identifiers within a specific domain
-               (DOMAIN, self.pa_sensor_id),
-               (DOMAIN, self.pa_ip_address)
-           },
-           "name": f'{self.pa_sensor_name} {MANUFACTURER}',
-           "manufacturer": MANUFACTURER,
-           "model": f'{self._data["model"]} ({self.pa_ip_address})',
-           "sw_version": self._data['sw_version'],
-           "hw_version": self._data['hw_version']
+            "identifiers": {
+                # Serial numbers are unique identifiers within a specific domain
+                (DOMAIN, self.pa_sensor_id),
+                (DOMAIN, self.pa_ip_address),
+            },
+            "name": f"{self.pa_sensor_name} {MANUFACTURER}",
+            "manufacturer": MANUFACTURER,
+            "model": f"{self._data['model']} ({self.pa_ip_address})",
+            "sw_version": self._data["sw_version"],
+            "hw_version": self._data["hw_version"],
         }
 
     @property
@@ -69,11 +103,11 @@ class PurpleAirQualitySensor(SensorEntity):
 
     @property
     def name(self):
-        nice_entity_title = self.idx.replace('_', ' ').title()
-        if 'air_quality_index' in self.idx:
-            left, last = nice_entity_title.rsplit(' ', 1)
-            nice_entity_title = f'{left} ({last.upper()})'
-        return f'{self.pa_sensor_name} {nice_entity_title}'
+        nice_entity_title = self.idx.replace("_", " ").title()
+        if "air_quality_index" in self.idx:
+            left, last = nice_entity_title.rsplit(" ", 1)
+            nice_entity_title = f"{left} ({last.upper()})"
+        return f"{self.pa_sensor_name} {nice_entity_title}"
 
     @property
     def native_value(self):
@@ -81,11 +115,11 @@ class PurpleAirQualitySensor(SensorEntity):
 
     @property
     def state_class(self):
-        return 'measurement' if self._uom is not None else None
+        return "measurement" if self._uom is not None else None
 
     @property
     def unique_id(self):
-        return f'{self.pa_sensor_id}_{self.idx}'
+        return f"{self.pa_sensor_id}_{self.idx}"
 
     @property
     def should_poll(self):
@@ -96,11 +130,14 @@ class PurpleAirQualitySensor(SensorEntity):
         return self._api.is_node_registered(self.pa_sensor_id)
 
     async def async_added_to_hass(self):
-        self._api.register_node(self.pa_sensor_id, self.pa_ip_address)
+        self._api.register_node(
+            self.pa_sensor_id,
+            self.pa_ip_address,
+            self._temp_offset,
+            self._humidity_offset,
+        )
         self._stop_listening = async_dispatcher_connect(
-            self._hass,
-            DISPATCHER_PURPLE_AIR,
-            self.async_write_ha_state
+            self._hass, DISPATCHER_PURPLE_AIR, self.async_write_ha_state
         )
 
     async def async_will_remove_from_hass(self):

--- a/custom_components/purpleair/strings.json
+++ b/custom_components/purpleair/strings.json
@@ -6,7 +6,15 @@
         "description": "To connect to a PurpleAir station, find the station you want to configure on the PurpleAir map, select it, and in the popup, click on \"Get This Widget\" and copy the JSON link.\n\nIf you are configuring more than one station, it will take up to 5 minutes for the station data to start flowing.",
         "title": "Connect to a PurpleAir Station",
         "data": {
-          "url": "Station JSON URL"
+          "url": "Station JSON URL",
+          "ip_address": "IP Address",
+          "name": "Name",
+          "temp_offset": "Temperature Offset (°F)",
+          "humidity_offset": "Humidity Offset (%)"
+        },
+        "data_description": {
+          "temp_offset": "Adjustment to apply to temperature readings (default: -8°F)",
+          "humidity_offset": "Adjustment to apply to humidity readings (default: +4%)"
         }
       }
     },
@@ -16,6 +24,22 @@
     },
     "abort": {
       "already_configured": "This PurpleAir station ID is already registered."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "PurpleAir Options",
+        "description": "Configure temperature and humidity offset adjustments",
+        "data": {
+          "temp_offset": "Temperature Offset (°F)",
+          "humidity_offset": "Humidity Offset (%)"
+        },
+        "data_description": {
+          "temp_offset": "Adjustment to apply to temperature readings (default: -8°F)",
+          "humidity_offset": "Adjustment to apply to humidity readings (default: +4%)"
+        }
+      }
     }
   }
 }

--- a/custom_components/purpleair/translations/en.json
+++ b/custom_components/purpleair/translations/en.json
@@ -1,23 +1,45 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "This Purple Air station ID is already registered."
+  "title": "PurpleAir",
+  "config": {
+    "step": {
+      "user": {
+        "description": "To connect to a PurpleAir station, find the station you want to configure on the PurpleAir map, select it, and in the popup, click on \"Get This Widget\" and copy the JSON link.\n\nIf you are configuring more than one station, it will take up to 5 minutes for the station data to start flowing.",
+        "title": "Connect to a PurpleAir Station",
+        "data": {
+          "url": "Station JSON URL",
+          "ip_address": "IP Address",
+          "name": "Name",
+          "temp_offset": "Temperature Offset (°F)",
+          "humidity_offset": "Humidity Offset (%)"
         },
-        "error": {
-            "cannot_connect": "Failed to connect, please try again.",
-            "invalid_ip_address": "The IP Address provided is invalid, inaccessible or not a PurpleAir device",
-            "unknown": "An unknown error occurred."
-        },
-        "step": {
-            "user": {
-                "data": {
-                    "name": "Device name",
-                    "ip_address": "Purple Air IP address"
-                },
-                "description": "Enter the IP Address of your local PurpleAir station",
-                "title": "Connect to a PurpleAir Station"
-            }
+        "data_description": {
+          "temp_offset": "Adjustment to apply to temperature readings (default: -8°F)",
+          "humidity_offset": "Adjustment to apply to humidity readings (default: +4%)"
         }
+      }
     },
-    "title": "PurpleAir"
+    "error": {
+      "cannot_connect": "Failed to connect, please try again.",
+      "unknown": "An unknown error occurred."
+    },
+    "abort": {
+      "already_configured": "This PurpleAir station ID is already registered."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "PurpleAir Options",
+        "description": "Configure temperature and humidity offset adjustments",
+        "data": {
+          "temp_offset": "Temperature Offset (°F)",
+          "humidity_offset": "Humidity Offset (%)"
+        },
+        "data_description": {
+          "temp_offset": "Adjustment to apply to temperature readings (default: -8°F)",
+          "humidity_offset": "Adjustment to apply to humidity readings (default: +4%)"
+        }
+      }
+    }
+  }
 }

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the PurpleAir integration."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,73 @@
+"""Fixtures for PurpleAir integration tests."""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.const import CONF_IP_ADDRESS
+from custom_components.purpleair.const import (
+    DOMAIN,
+    CONF_TEMP_OFFSET,
+    CONF_HUMIDITY_OFFSET,
+    TEMP_ADJUSTMENT,
+    HUMIDITY_ADJUSTMENT,
+)
+
+
+pytest_plugins = "pytest_homeassistant_custom_component"
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Enable custom integrations for all tests."""
+    yield
+
+
+@pytest.fixture
+def mock_purpleair_device():
+    """Mock a PurpleAir device response."""
+    return {
+        "SensorId": "12345",
+        "place": "Test Location",
+        "version": "7.00",
+        "hardwareversion": "2.0",
+        "hardwarediscovered": "2.0+BME280+PMSX003-B+PMSX003-A",
+        "current_temp_f": 75,
+        "current_humidity": 50,
+        "current_dewpoint_f": 55,
+        "pressure": 1013.25,
+        "pm1_0_atm": 5.0,
+        "pm2_5_atm": 10.0,
+        "pm10_0_atm": 15.0,
+        "pm2.5_aqi": 42,
+        "pm2.5_aqi_b": 41,
+        "pm1_0_atm_b": 5.1,
+        "pm2_5_atm_b": 10.1,
+        "pm10_0_atm_b": 15.1,
+        "rssi": -45,
+    }
+
+
+@pytest.fixture
+def mock_config_entry_data():
+    """Mock config entry data."""
+    return {
+        "title": "Test PurpleAir",
+        "place": "Test Location",
+        "id": "12345",
+        CONF_IP_ADDRESS: "192.168.1.100",
+        "sw_version": "7.00",
+        "hw_version": "2.0",
+        "model": "PA-II",
+        "is_dual": True,
+        CONF_TEMP_OFFSET: TEMP_ADJUSTMENT,
+        CONF_HUMIDITY_OFFSET: HUMIDITY_ADJUSTMENT,
+    }
+
+
+@pytest.fixture
+def mock_config_entry_options():
+    """Mock config entry options."""
+    return {
+        CONF_TEMP_OFFSET: TEMP_ADJUSTMENT,
+        CONF_HUMIDITY_OFFSET: HUMIDITY_ADJUSTMENT,
+    }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,113 @@
+"""Test the PurpleAir config flow."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant import config_entries
+from homeassistant.const import CONF_IP_ADDRESS, CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from custom_components.purpleair.const import (
+    DOMAIN,
+    CONF_TEMP_OFFSET,
+    CONF_HUMIDITY_OFFSET,
+    TEMP_ADJUSTMENT,
+    HUMIDITY_ADJUSTMENT,
+)
+
+
+async def test_form(hass: HomeAssistant, mock_purpleair_device) -> None:
+    """Test we get the form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {}
+
+    with patch(
+        "custom_components.purpleair.config_flow.async_get_clientsession"
+    ) as mock_session:
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value=mock_purpleair_device)
+        mock_session.return_value.get.return_value.__aenter__.return_value = (
+            mock_response
+        )
+
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_IP_ADDRESS: "192.168.1.100",
+                CONF_NAME: "Test PurpleAir",
+                CONF_TEMP_OFFSET: TEMP_ADJUSTMENT,
+                CONF_HUMIDITY_OFFSET: HUMIDITY_ADJUSTMENT,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "Test PurpleAir"
+    assert result2["data"] == {
+        "title": "Test PurpleAir",
+        "place": "Test Location",
+        "id": "12345",
+        "ip_address": "192.168.1.100",
+        "sw_version": "7.00",
+        "hw_version": "2.0",
+        "model": "PA-II",
+        "is_dual": True,
+        CONF_TEMP_OFFSET: TEMP_ADJUSTMENT,
+        CONF_HUMIDITY_OFFSET: HUMIDITY_ADJUSTMENT,
+    }
+
+
+async def test_form_invalid_ip(hass: HomeAssistant) -> None:
+    """Test we handle invalid IP."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_IP_ADDRESS: "invalid",
+            CONF_NAME: "Test PurpleAir",
+        },
+    )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": "invalid_ip_address"}
+
+
+async def test_options_flow(
+    hass: HomeAssistant, mock_config_entry_data, mock_config_entry_options
+) -> None:
+    """Test options flow."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=mock_config_entry_data,
+        options=mock_config_entry_options,
+    )
+    config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_TEMP_OFFSET: -10,
+            CONF_HUMIDITY_OFFSET: 5,
+        },
+    )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        CONF_TEMP_OFFSET: -10,
+        CONF_HUMIDITY_OFFSET: 5,
+    }


### PR DESCRIPTION
The integration is set up by default with the same offset for temperature and humidity that is found in the official javascript, compensating for the case's effect on those values.

This adds a configuration flow for the integration to tweak those, when necessary.